### PR TITLE
fix address overflow BUG

### DIFF
--- a/src/sys_morecore.c
+++ b/src/sys_morecore.c
@@ -78,11 +78,11 @@ sys_mmap2(va_list ap)
     (void)fd;
     (void)offset;
     if (flags & MAP_ANONYMOUS) {
+      if (length > morecore_top - morecore_base) {
+        return -ENOMEM;
+      }
         /* Steal from the top */
         uintptr_t base = morecore_top - length;
-        if (base < morecore_base) {
-            return -ENOMEM;
-        }
         morecore_top = base;
         return base;
     }


### PR DESCRIPTION
There is address  overflow in `mmap2()`. If `length` is greater than `morecore_top`, then the result `base` will overflow and be like `0xffff0000`, which of course pass the bound check, and the `malloc` may get addresses that lead to page fault.
This patch fix this problem.
